### PR TITLE
Changed sf::Event::Type to sf::Event::EventType for easier compatibli…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ else()
     # add the non-optional SFML headers
     add_custom_command(TARGET SFML POST_BUILD COMMAND cp -r
                        ${PROJECT_SOURCE_DIR}/include/SFML/Config.hpp
+                       ${PROJECT_SOURCE_DIR}/include/SFML/Compatibility.hpp
                        ${PROJECT_SOURCE_DIR}/include/SFML/OpenGL.hpp
                        ${PROJECT_SOURCE_DIR}/include/SFML/GpuPreference.hpp
                        ${PROJECT_SOURCE_DIR}/include/SFML/System.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ if(SFML_BUILD_WINDOW)
     sfml_set_option(SFML_OPENGL_ES ${OPENGL_ES} BOOL "TRUE to use an OpenGL ES implementation, FALSE to use a desktop OpenGL implementation")
 endif()
 
+# add an option for SFML compatibility, temporarily
+sfml_set_option(MML_SFML_COMPAT FALSE BOOL "TRUE to include API alterations allowing compatibility with SFML")
+
 # Mac OS X specific options
 if(SFML_OS_MACOSX)
     # add an option to build frameworks instead of dylibs (release only)

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -47,7 +47,7 @@ namespace
     // Update joystick axes
     void updateAxes(unsigned int index)
     {
-        for (unsigned int j = 0; j < static_cast<unsigned int>(sf::Joystick::Axis::Count); ++j)
+        for (unsigned int j = 0; j < static_cast<unsigned int>(sf::Joystick::AxisCount); ++j)
         {
             if (sf::Joystick::hasAxis(index, static_cast<sf::Joystick::Axis>(j)))
                 set(axislabels[j], sf::Joystick::getAxisPosition(index, static_cast<sf::Joystick::Axis>(j)));
@@ -118,7 +118,7 @@ int main()
     texts["Threshold"].value.setString(sstr.str());
 
     // Set up our label-value sf::Text objects
-    for (unsigned int i = 0; i < static_cast<unsigned int>(sf::Joystick::Axis::Count); ++i)
+    for (unsigned int i = 0; i < static_cast<unsigned int>(sf::Joystick::AxisCount); ++i)
     {
         JoystickObject& object = texts[axislabels[i]];
 
@@ -135,10 +135,10 @@ int main()
         sstr << "Button " << i;
         JoystickObject& object = texts[sstr.str()];
 
-        object.label.setPosition(5.f, 5.f + ((static_cast<int>(sf::Joystick::Axis::Count) + i + 4) * font.getLineSpacing(14)));
+        object.label.setPosition(5.f, 5.f + ((static_cast<int>(sf::Joystick::AxisCount) + i + 4) * font.getLineSpacing(14)));
         object.label.setString(sstr.str() + ":");
 
-        object.value.setPosition(80.f, 5.f + ((static_cast<int>(sf::Joystick::Axis::Count) + i + 4) * font.getLineSpacing(14)));
+        object.value.setPosition(80.f, 5.f + ((static_cast<int>(sf::Joystick::AxisCount) + i + 4) * font.getLineSpacing(14)));
         object.value.setString("N/A");
     }
 

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/AlResource.hpp>
 #include <SFML/System/Vector3.hpp>
@@ -47,7 +48,7 @@ public:
     /// \brief Enumeration of the sound source states
     ///
     ////////////////////////////////////////////////////////////
-    enum class Status : unsigned char
+    MML_COMPAT_ENUM Status
     {
         Stopped, ///< Sound is not playing
         Paused,  ///< Sound is paused

--- a/include/SFML/Compatibility.hpp
+++ b/include/SFML/Compatibility.hpp
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_COMPATIBILITY_HPP
+#define SFML_COMPATIBILITY_HPP
+
+#ifdef MML_SFML_COMPAT
+    #define MML_COMPAT_ENUM enum
+#else
+    #define MML_COMPAT_ENUM enum class
+#endif
+
+#ifdef MML_SFML_COMPAT
+    #define MML_COMPAT_ALIAS(newName, aliasExpr) static constexpr auto newName = aliasExpr;
+#else
+    #define MML_COMPAT_ALIAS(newName, aliasExpr)
+#endif
+
+#endif // SFML_COMPATIBILITY_HPP

--- a/include/SFML/Graphics/BlendMode.hpp
+++ b/include/SFML/Graphics/BlendMode.hpp
@@ -28,8 +28,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Graphics/Export.hpp>
-
 
 namespace sf
 {
@@ -46,7 +46,7 @@ struct SFML_GRAPHICS_API BlendMode
     /// The factors are mapped directly to their OpenGL equivalents,
     /// specified by glBlendFunc() or glBlendFuncSeparate().
     ////////////////////////////////////////////////////////
-    enum class Factor : unsigned char
+    MML_COMPAT_ENUM Factor
     {
         Zero,             ///< (0, 0, 0, 0)
         One,              ///< (1, 1, 1, 1)
@@ -66,7 +66,7 @@ struct SFML_GRAPHICS_API BlendMode
     /// The equations are mapped directly to their OpenGL equivalents,
     /// specified by glBlendEquation() or glBlendEquationSeparate().
     ////////////////////////////////////////////////////////
-    enum class Equation : unsigned char
+    MML_COMPAT_ENUM Equation
     {
         Add,            ///< Pixel = Src * SrcFactor + Dst * DstFactor
         Subtract,       ///< Pixel = Src * SrcFactor - Dst * DstFactor

--- a/include/SFML/Graphics/PrimitiveType.hpp
+++ b/include/SFML/Graphics/PrimitiveType.hpp
@@ -25,6 +25,8 @@
 #ifndef SFML_PRIMITIVETYPE_HPP
 #define SFML_PRIMITIVETYPE_HPP
 
+#include <SFML/Compatibility.hpp>
+
 namespace sf
 {
 ////////////////////////////////////////////////////////////
@@ -36,7 +38,7 @@ namespace sf
 /// and view.
 ///
 ////////////////////////////////////////////////////////////
-enum class PrimitiveType : unsigned char
+MML_COMPAT_ENUM PrimitiveType
 {
     Points,        ///< List of individual points
     Lines,         ///< List of individual lines

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Glsl.hpp>
 #include <SFML/Window/GlResource.hpp>
@@ -57,7 +58,7 @@ public:
     /// \brief Types of shaders
     ///
     ////////////////////////////////////////////////////////////
-    enum class Type : unsigned char
+    MML_COMPAT_ENUM Type
     {
         Vertex,   ///< %Vertex shader
         Geometry, ///< Geometry shader

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Network/Export.hpp>
 #include <SFML/Network/TcpSocket.hpp>
 #include <SFML/System/NonCopyable.hpp>
@@ -52,7 +53,7 @@ public:
     /// \brief Enumeration of transfer modes
     ///
     ////////////////////////////////////////////////////////////
-    enum class TransferMode : unsigned char
+    MML_COMPAT_ENUM TransferMode
     {
         Binary, ///< Binary mode (file is transfered as a sequence of bytes)
         Ascii,  ///< Text mode using ASCII encoding
@@ -71,7 +72,7 @@ public:
         /// \brief Status codes possibly returned by a FTP response
         ///
         ////////////////////////////////////////////////////////////
-        enum class Status : unsigned short
+        MML_COMPAT_ENUM Status
         {
             // 1xx: the requested action is being initiated,
             // expect another reply before proceeding with a new command

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Network/Export.hpp>
 #include <SFML/Network/IpAddress.hpp>
 #include <SFML/Network/TcpSocket.hpp>
@@ -59,7 +60,7 @@ public:
         /// \brief Enumerate the available HTTP methods for a request
         ///
         ////////////////////////////////////////////////////////////
-        enum class Method : unsigned char
+        MML_COMPAT_ENUM Method
         {
             Get,   ///< Request in get mode, standard method to retrieve a page
             Post,  ///< Request in post mode, usually to send data to a page
@@ -198,7 +199,7 @@ public:
         /// \brief Enumerate all the valid status codes for a response
         ///
         ////////////////////////////////////////////////////////////
-        enum class Status : unsigned short
+        MML_COMPAT_ENUM Status
         {
             // 2xx: success
             Ok             = 200, ///< Most common code returned when operation was successful

--- a/include/SFML/Network/Socket.hpp
+++ b/include/SFML/Network/Socket.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Network/Export.hpp>
 #include <SFML/Network/SocketHandle.hpp>
 #include <SFML/System/NonCopyable.hpp>
@@ -50,7 +51,7 @@ public:
     /// \brief Status codes that may be returned by socket functions
     ///
     ////////////////////////////////////////////////////////////
-    enum class Status : unsigned char
+    MML_COMPAT_ENUM Status
     {
         Done,         ///< The socket has sent / received the data
         NotReady,     ///< The socket is not ready to send / receive data yet

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
+#include <SFML/Compatibility.hpp>
 #include <SFML/Window/Joystick.hpp>
 #include <SFML/Window/Keyboard.hpp>
 #include <SFML/Window/Mouse.hpp>
@@ -184,7 +185,7 @@ public:
     /// \brief Enumeration of the different types of events
     ///
     ////////////////////////////////////////////////////////////
-    enum class Type : unsigned char
+    MML_COMPAT_ENUM Type
     {
         Closed,                 ///< The window requested to be closed (no data)
         Resized,                ///< The window was resized (data in event.size)

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -212,6 +212,11 @@ public:
 
         Count                   ///< Keep last -- the total number of event types
     };
+    
+    // To allow sf::Event::EventType compatibility
+#ifdef MML_SFML_COMPAT
+    using EventType = Type;
+#endif
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -50,14 +50,15 @@ public:
     enum
     {
         Count       = 8,  ///< Maximum number of supported joysticks
-        ButtonCount = 32  ///< Maximum number of supported buttons
+        ButtonCount = 32, ///< Maximum number of supported buttons
+        AxisCount   = 8   ///< Maximum number of supported axes
     };
 
     ////////////////////////////////////////////////////////////
     /// \brief Axes supported by SFML joysticks
     ///
     ////////////////////////////////////////////////////////////
-    enum class Axis : unsigned char
+    MML_COMPAT_ENUM Axis
     {
         X,    ///< The X axis
         Y,    ///< The Y axis
@@ -67,19 +68,7 @@ public:
         V,    ///< The V axis
         PovX, ///< The X axis of the point-of-view hat
         PovY, ///< The Y axis of the point-of-view hat
-
-        Count ///< Maximum number of supported axes
     };
-    
-    MML_COMPAT_ALIAS(X, Axis::X)
-    MML_COMPAT_ALIAS(Y, Axis::Y)
-    MML_COMPAT_ALIAS(Z, Axis::Z)
-    MML_COMPAT_ALIAS(R, Axis::R)
-    MML_COMPAT_ALIAS(U, Axis::U)
-    MML_COMPAT_ALIAS(V, Axis::V)
-    MML_COMPAT_ALIAS(PovX, Axis::PovX)
-    MML_COMPAT_ALIAS(PovY, Axis::PovY)
-    MML_COMPAT_ALIAS(AxisCount, Axis::Count)
 
     ////////////////////////////////////////////////////////////
     /// \brief Structure holding a joystick's identification

--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Window/Export.hpp>
 #include <SFML/System/String.hpp>
 
@@ -69,6 +70,16 @@ public:
 
         Count ///< Maximum number of supported axes
     };
+    
+    MML_COMPAT_ALIAS(X, Axis::X)
+    MML_COMPAT_ALIAS(Y, Axis::Y)
+    MML_COMPAT_ALIAS(Z, Axis::Z)
+    MML_COMPAT_ALIAS(R, Axis::R)
+    MML_COMPAT_ALIAS(U, Axis::U)
+    MML_COMPAT_ALIAS(V, Axis::V)
+    MML_COMPAT_ALIAS(PovX, Axis::PovX)
+    MML_COMPAT_ALIAS(PovY, Axis::PovY)
+    MML_COMPAT_ALIAS(AxisCount, Axis::Count)
 
     ////////////////////////////////////////////////////////////
     /// \brief Structure holding a joystick's identification

--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Window/Export.hpp>
 
 
@@ -45,7 +46,7 @@ public:
     /// \brief Key codes
     ///
     ////////////////////////////////////////////////////////////
-    enum class Key : unsigned char
+    MML_COMPAT_ENUM Key
     {
         Unknown = static_cast<unsigned char>(-1), ///< Unhandled key
 
@@ -161,6 +162,8 @@ public:
         SemiColon = Semicolon,    ///< \deprecated Use Semicolon instead
         Return    = Enter         ///< \deprecated Use Enter instead
     };
+    
+    MML_COMPAT_ALIAS(KeyCount, Key::Count)
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if a key is pressed

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -59,14 +59,14 @@ public:
 
         Count       ///< Keep last -- the total number of mouse buttons
     };
-    
+
     MML_COMPAT_ALIAS(ButtonCount, Button::Count)
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse wheels
     ///
     ////////////////////////////////////////////////////////////
-    enum class Wheel : unsigned char
+    MML_COMPAT_ENUM Wheel
     {
         VerticalWheel,  ///< The vertical mouse wheel
         HorizontalWheel ///< The horizontal mouse wheel

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Window/Export.hpp>
 #include <SFML/System/Vector2.hpp>
 
@@ -48,7 +49,7 @@ public:
     /// \brief Mouse buttons
     ///
     ////////////////////////////////////////////////////////////
-    enum class Button : unsigned char
+    MML_COMPAT_ENUM Button
     {
         Left,       ///< The left mouse button
         Right,      ///< The right mouse button
@@ -58,6 +59,8 @@ public:
 
         Count       ///< Keep last -- the total number of mouse buttons
     };
+    
+    MML_COMPAT_ALIAS(ButtonCount, Button::Count)
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse wheels

--- a/include/SFML/Window/Sensor.hpp
+++ b/include/SFML/Window/Sensor.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Compatibility.hpp>
 #include <SFML/Window/Export.hpp>
 #include <SFML/System/Vector3.hpp>
 #include <SFML/System/Time.hpp>
@@ -47,7 +48,7 @@ public:
     /// \brief Sensor type
     ///
     ////////////////////////////////////////////////////////////
-    enum class Type : unsigned char
+    MML_COMPAT_ENUM Type
     {
         Accelerometer,    ///< Measures the raw acceleration (m/s^2)
         Gyroscope,        ///< Measures the raw rotation rates (degrees/s)

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -242,6 +242,12 @@ if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
     set(OpenGL_GL_PREFERENCE "LEGACY")
 endif()
 
+# Compatibility for:
+# - sf::Event::EventType
+if(MML_SFML_COMPAT)
+    target_compile_definitions(sfml-window PUBLIC "-DMML_SFML_COMPAT")
+endif()
+
 if(SFML_OPENGL_ES)
     if(SFML_OS_IOS)
         target_link_libraries(sfml-window PRIVATE "-framework OpenGLES")

--- a/src/SFML/Window/JoystickImpl.hpp
+++ b/src/SFML/Window/JoystickImpl.hpp
@@ -51,7 +51,7 @@ struct JoystickCaps
     }
 
     unsigned int buttonCount;               ///< Number of buttons supported by the joystick
-    bool         axes[static_cast<size_t>(Joystick::Axis::Count)]; ///< Support for each axis
+    bool         axes[Joystick::AxisCount]; ///< Support for each axis
 };
 
 
@@ -69,7 +69,7 @@ struct JoystickState
     }
 
     bool  connected;                      ///< Is the joystick currently connected?
-    float axes[static_cast<size_t>(Joystick::Axis::Count)];      ///< Position of each axis, in range [-100, 100]
+    float axes[Joystick::AxisCount];      ///< Position of each axis, in range [-100, 100]
     bool  buttons[Joystick::ButtonCount]; ///< Status of each button (true = pressed)
 };
 

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -96,7 +96,7 @@ namespace
     };
     const sf::Time connectionRefreshDelay = sf::milliseconds(500);
 
-    ConnectionCache connectionCache[sf::Joystick::Count];
+    ConnectionCache connectionCache[sf::JoystickCount];
 
     // If true, will only update when WM_DEVICECHANGE message is received
     bool lazyUpdates = false;
@@ -252,7 +252,7 @@ void JoystickImpl::updateConnections()
     if (directInput)
         return updateConnectionsDInput();
 
-    for (unsigned int i = 0; i < Joystick::Count; ++i)
+    for (unsigned int i = 0; i < JoystickCount; ++i)
     {
         JOYINFOEX joyInfo;
         joyInfo.dwSize = sizeof(joyInfo);
@@ -491,7 +491,7 @@ bool JoystickImpl::openDInput(unsigned int index)
     // Initialize DirectInput members
     m_device = NULL;
 
-    for (int i = 0; i < static_cast<int>(Joystick::Axis::Count); ++i)
+    for (int i = 0; i < static_cast<int>(Joystick::AxisCount); ++i)
         m_axes[i] = -1;
 
     for (int i = 0; i < Joystick::ButtonCount; ++i)
@@ -701,7 +701,7 @@ JoystickCaps JoystickImpl::getCapabilitiesDInput() const
     }
 
     // Check which axes have valid offsets
-    for (int i = 0; i < static_cast<int>(Joystick::Axis::Count); ++i)
+    for (int i = 0; i < static_cast<int>(Joystick::AxisCount); ++i)
         caps.axes[i] = (m_axes[i] != -1);
 
     return caps;
@@ -748,7 +748,7 @@ JoystickState JoystickImpl::updateDInput()
         }
 
         // Get the current state of each axis
-        for (int i = 0; i < static_cast<int>(Joystick::Axis::Count); ++i)
+        for (int i = 0; i < static_cast<int>(Joystick::AxisCount); ++i)
         {
             if (m_axes[i] != -1)
             {
@@ -828,7 +828,7 @@ BOOL CALLBACK JoystickImpl::deviceEnumerationCallback(const DIDEVICEINSTANCE* de
         }
     }
 
-    JoystickRecord record = { deviceInstance->guidInstance, sf::Joystick::Count, true };
+    JoystickRecord record = { deviceInstance->guidInstance, sf::JoystickCount, true };
     joystickList.push_back(record);
 
     return DIENUM_CONTINUE;

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -96,7 +96,7 @@ namespace
     };
     const sf::Time connectionRefreshDelay = sf::milliseconds(500);
 
-    ConnectionCache connectionCache[sf::JoystickCount];
+    ConnectionCache connectionCache[sf::Joystick::Count];
 
     // If true, will only update when WM_DEVICECHANGE message is received
     bool lazyUpdates = false;
@@ -252,7 +252,7 @@ void JoystickImpl::updateConnections()
     if (directInput)
         return updateConnectionsDInput();
 
-    for (unsigned int i = 0; i < JoystickCount; ++i)
+    for (unsigned int i = 0; i < Joystick::Count; ++i)
     {
         JOYINFOEX joyInfo;
         joyInfo.dwSize = sizeof(joyInfo);
@@ -828,7 +828,7 @@ BOOL CALLBACK JoystickImpl::deviceEnumerationCallback(const DIDEVICEINSTANCE* de
         }
     }
 
-    JoystickRecord record = { deviceInstance->guidInstance, sf::JoystickCount, true };
+    JoystickRecord record = { deviceInstance->guidInstance, sf::Joystick::Count, true };
     joystickList.push_back(record);
 
     return DIENUM_CONTINUE;

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -224,7 +224,7 @@ private:
     JOYCAPS                  m_caps;                           ///< Joystick capabilities
     IDirectInputDevice8W*    m_device;                         ///< DirectInput 8.x device
     DIDEVCAPS                m_deviceCaps;                     ///< DirectInput device capabilities
-    int                      m_axes[Joystick::Axis::Count];      ///< Offsets to the bytes containing the axes states, -1 if not available
+    int                      m_axes[Joystick::AxisCount];      ///< Offsets to the bytes containing the axes states, -1 if not available
     int                      m_buttons[Joystick::ButtonCount]; ///< Offsets to the bytes containing the button states, -1 if not available
     Joystick::Identification m_identification;                 ///< Joystick identification
 };

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -88,7 +88,7 @@ m_joystickThreshold(0.1f)
     for (unsigned int i = 0; i < Joystick::Count; ++i)
     {
         m_joystickStates[i] = JoystickManager::getInstance().getState(i);
-        std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::Axis::Count), 0.f);
+        std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::AxisCount), 0.f);
     }
 
     // Get the initial sensor states
@@ -182,13 +182,13 @@ void WindowImpl::processJoystickEvents()
 
             // Clear previous axes positions
             if (connected)
-                std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::Axis::Count), 0.f);
+                std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::AxisCount), 0.f);
         }
 
         if (connected)
         {
             // Axes
-            for (auto axisIndex = 0u; axisIndex < static_cast<size_t>(Joystick::Axis::Count); ++axisIndex)
+            for (auto axisIndex = 0u; axisIndex < Joystick::AxisCount; ++axisIndex)
             {
                 if (caps.axes[axisIndex])
                 {

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -276,7 +276,7 @@ private:
     JoystickState     m_joystickStates[Joystick::Count];                       ///< Previous state of the joysticks
     Vector3f          m_sensorValue[static_cast<size_t>(Sensor::Type::Count)]; ///< Previous value of the sensors
     float             m_joystickThreshold;                                     ///< Joystick threshold (minimum motion for "move" event to be generated)
-    float             m_previousAxes[Joystick::Count][static_cast<int>(Joystick::Axis::Count)];  ///< Position of each axis last time a move event triggered, in range [-100, 100]
+    float             m_previousAxes[Joystick::Count][static_cast<int>(Joystick::AxisCount)];  ///< Position of each axis last time a move event triggered, in range [-100, 100]
 };
 
 } // namespace priv


### PR DESCRIPTION
Allows projects to switch back to SFML without errors (assuming c++11 capable compiler)

This is toggleable by enabling the MML_SFML_COMPAT cmake option