### PR TITLE
Disable autocorrect on iOS 

### DIFF
--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -202,5 +202,11 @@
     return self;
 }
 
+////////////////////////////////////////////////////////////
+- (UITextAutocorrectionType) autocorrectionType
+{
+    return UITextAutocorrectionTypeNo;
+}
+
 
 @end


### PR DESCRIPTION
It's bugged, this removes it which is the best I can do for now...