### PR TITLE
Cocoa fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,16 +47,14 @@ matrix:
     - GENERATOR="Unix Makefiles"
     - CMAKE_FLAGS="-DSFML_BUILD_EXAMPLES=TRUE"
 
-  # macOS - Xcode 9
+  # macOS - Xcode
   - os: osx
-    osx_image: xcode9
     env:
     - GENERATOR="Xcode"
     - CMAKE_FLAGS="-DSFML_BUILD_FRAMEWORKS=TRUE -DSFML_BUILD_EXAMPLES=TRUE"
 
-  # iOS - Xcode 9
+  # iOS - Xcode
   - os: osx
-    osx_image: xcode9
     env:
     - GENERATOR="Xcode"
     - CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.toolchain.cmake -DSFML_BUILD_EXAMPLES=TRUE -DIOS_PLATFORM=SIMULATOR"

--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -20,7 +20,7 @@ function(compile_xib)
     endif()
 
     # Default args taken from Xcode 9 when it generates a nib from a xib
-    set(DEFAULT_ARGS --errors --warnings --notices --module cocoa --auto-activate-custom-fonts --target-device mac --minimum-deployment-target ${CMAKE_OSX_DEPLOYMENT_TARGET} --output-format human-readable-text)
+    set(DEFAULT_ARGS --errors --warnings --notices --module cocoa --auto-activate-custom-fonts --target-device mac --output-format human-readable-text)
 
     add_custom_command(OUTPUT "${THIS_OUTPUT}"
         COMMAND "${IBTOOL}" ${DEFAULT_ARGS} "${THIS_INPUT}" --compile "${THIS_OUTPUT}"


### PR DESCRIPTION
Fixes an issue with the cocoa example on macOS 10.13, and also updated travis to use the default osx image which is 10.13 (previous setting forced it to use 10.12, which explains why this wasn't noticed before)